### PR TITLE
Change: Zvýšena důležitost tech-news na titulní stránce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ a projekt dodržuje [Semantic Versioning](https://semver.org/lang/cs/).
 - Povinnost aktualizovat CHANGELOG.md po každém commitu
 - Archiv odkaz v headeru `/tech-news/` stránky - viditelný hned při načtení
 - HTML verze CHANGELOGu dostupná na `/changelog/` s odkazem v patičce webu
-- Sekce "Tech News" na titulní stránce - zobrazuje 5 nejnovějších článků se střední a vysokou důležitostí (importance >= 3)
+- Sekce "Tech News" na titulní stránce - zobrazuje maximálně 5 nejnovějších článků s vysokou důležitostí (importance >= 4)
 
 ### Fixed
 - Permalinky v `_layouts/tech_news_day.html` - články nyní vedou na interní stránky `/tech-news/YYYY-MM-DD/slug/` místo externích URL

--- a/index.html
+++ b/index.html
@@ -262,7 +262,7 @@ layout: default
   </style>
 
   <!-- Tech News Section -->
-  {% assign high_importance_news = site.tech_news | where_exp: "article", "article.importance >= 3" | sort: 'publishedAt' | reverse | limit: 5 %}
+  {% assign high_importance_news = site.tech_news | where_exp: "article", "article.importance >= 4" | sort: 'publishedAt' | reverse | limit: 5 %}
 
   {% if high_importance_news.size > 0 %}
   <div id="tech-news-brief">


### PR DESCRIPTION
- Změněn filtr z importance >= 3 na >= 4
- Zobrazují se pouze nejdůležitější zprávy (max 5 článků)
- Limit 5 článků zůstává zachován

Detaily v CHANGELOG.md