### PR TITLE
Fix: move AI handbook post to Hugo content directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ a projekt dodržuje [Semantic Versioning](https://semver.org/lang/cs/).
 ## [Unreleased]
 
 ### Fixed
+- Post `prirucka-ai-ve-firmach-zdarma` přesunut z `_posts/` do `content/posts/` pro kompatibilitu s Hugo buildem
 - Accessibility: přidán skip-to-content link do default.html a aiprace.html layoutů
 - Accessibility: emoji search link doplněn o `aria-label="Hledat"` (WCAG 2.4.6)
 - Accessibility: `<p datetime>` opraven na validní `<time datetime>` v post.html

--- a/content/posts/2026/2026-04-03-prirucka-ai-ve-firmach-zdarma.md
+++ b/content/posts/2026/2026-04-03-prirucka-ai-ve-firmach-zdarma.md
@@ -1,0 +1,26 @@
+---
+slug: 'prirucka-ai-ve-firmach-zdarma'
+author: Patrick Zandl
+categories:
+- AI
+layout: post
+post_excerpt: Jak implementovat AI do firem? Jak začít umělou inteligenci využívat pro práci? Přichystal jsem vám příručku. PDF verzi si můžete stáhnout zdarma, na dubnovém Vibecoding Talks budou i tištěné.
+title: Jak začít umělou inteligenci využívat pro práci? Ebook zdarma!
+thumbnail: https://www.marigold.cz/assets/ebook-ai-ve-firmach.png
+---
+
+Jak implementovat AI do firem? Jak začít umělou inteligenci využívat pro práci? Přichystal jsem vám příručku. [PDF verzi si můžete stáhnout zdarma](https://www.vibecoding.cz/prirucka/), na dubnovém [Vibecoding Talks](https://www.vibecoding.cz/akce/vibecoding-talks-duben-2026) budou i tištěné.
+
+Příručka měl být malý letáček s pár tipy. Jenže téma je tak hluboké a tak zanesené marketingovým balastem, že jsem raději napsal sice stručnou, ale stejně třicetistránkovou příručku s postupem, tipy a radmi, jak umělou inteligenci ve firmě využívat. 
+
+[PDF verzi si můžete stáhnout zdarma](https://www.vibecoding.cz/prirucka/) - po registraci vám také přijdou jednou týdně emaily s pár tipy a kontrolními dotazy, jak vám to jde, abyste to neměli tak lehké. 
+
+A pokud na to nechcete být sami, zejména pro firmy, kde jsou vývojářské týmy, platí nabídka [workshopu pro vývojáře](https://www.aivefirmach.cz/ai-development-workshop/). V něm projdeme celé pracovní workflow a řekneme si, kde zrovna vám AI pomůže a kde ne. To z příručky nevyčtete, na to stačí půldenní workshop ve firmě nebo pár desítek hodin samostudia. 
+
+A co dalšího dělám pro vaše vzdělávání v AI?
+- [Letní škola AI](https://skola.prolnuto.cz/) stále běží a chystá se na léto. Čtyři týdny budete dostávat každý den malou lekci práce s AI, za čtyři týdny budete slušně v obraze. Je to myšleno pro naprosté začátečníky. Zdarma, emailem.
+- Moje konzultace na míru (a za peníze) jsou na [AI ve firmách](https://www.aivefirmach.cz)
+- Ale můžete si [rezervovat 20 minut call](https://fantastical.app/patrickzandl) nad tím, jestli jsou takové workshopy u vás ve firmě k něčemu vhodné
+- Videa [Claude Code s Patrickem](https://www.youtube.com/@Tangero) - pro vaše vzdělávání vibe codingu s Claude Code
+- setkání vývojářů Vibecoding Talks - [20.4.2026 v kině Dlabačov, registrujte se](https://www.vibecoding.cz/akce/vibecoding-talks-duben-2026)
+- [Workshopy vibecodingu pro fandy](https://www.vibecoding.cz/workshopy/)


### PR DESCRIPTION
Post was in _posts/ (Jekyll) but site now builds with Hugo,
so it needs to be in content/posts/. Added slug field for Hugo compatibility.

https://claude.ai/code/session_01L4LH2u2jaoKVPyeFsok3KH