### PR TITLE
Update workshop banner details and pricing

### DIFF
--- a/layouts/partials/workshop-banner.html
+++ b/layouts/partials/workshop-banner.html
@@ -4,12 +4,11 @@
       <div class="workshop-banner-content">
         <span class="workshop-banner-badge">Workshop</span>
         <div class="workshop-banner-title">Workshop Claude Code pro vývojáře s Patrickem</div>
-        <div class="workshop-banner-detail">21.4.2026 &middot; 14:00 &middot; V Olšinách 2300/75, Praha 10</div>
         <div class="workshop-banner-detail">Za 4 hodiny zvládneš CLAUDE.md, MCP servery a subagenty.</div>
-        <div class="workshop-banner-early">Early bird — pouze do 31.3.2026.</div>
+        <div class="workshop-banner-early">Termíny květen a červen ještě volné.</div>
       </div>
       <div class="workshop-banner-cta">
-        <div class="workshop-banner-price">3 000 Kč</div>
+        <div class="workshop-banner-price">4 000 Kč</div>
         <span class="workshop-banner-btn">Registrovat se &rarr;</span>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Updated the workshop banner content to reflect current workshop information, including revised pricing and availability messaging.

## Key Changes
- Removed specific date and location details (21.4.2026 & V Olšinách 2300/75, Praha 10)
- Updated early bird messaging from "Early bird — pouze do 31.3.2026" to "Termíny květen a červen ještě volné" to indicate May and June dates are still available
- Increased workshop price from 3,000 Kč to 4,000 Kč
- Retained the workshop description about learning CLAUDE.md, MCP servers, and subagents

## Implementation Details
These changes appear to be part of a workshop scheduling update, moving away from a specific April 2026 date with early bird pricing to a more flexible availability window in May and June with adjusted pricing.

https://claude.ai/code/session_01NWyzEjsEQQZ7G7UVzJyH4V