### PR TITLE
feat(promo-banner): podpora reklamních slotů (isAd)

### DIFF
--- a/static/js/promo-banner.js
+++ b/static/js/promo-banner.js
@@ -25,6 +25,13 @@
     .then(function (e) {
       if (!e || !e.slug) return;
 
+      // Data z API se vkládají do innerHTML — escapuj vše interpolované.
+      function esc(s) {
+        return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
+          return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+        });
+      }
+
       // Reklama / externí promo slot (isAd): nemá reálný termín ani město,
       // místo „Naše akce" má vlastní štítek a CTA „Více". Datum se nezobrazuje.
       var isAd = !!e.isAd;
@@ -37,8 +44,8 @@
         dateText = df + (city ? ' · ' + city : '') +
           (e.dateVariants && e.dateVariants.length > 1 ? ' · a další termíny' : '');
       }
-      var url = 'https://www.vibecoding.cz/akce/' + e.slug +
-        '/?utm_source=marigold&utm_medium=web&utm_campaign=' + campaign;
+      var url = 'https://www.vibecoding.cz/akce/' + encodeURIComponent(e.slug).replace(/%2F/gi, '/') +
+        '/?utm_source=marigold&utm_medium=web&utm_campaign=' + encodeURIComponent(campaign);
 
       if (e.isPaid) {
         // Tmavý workshop banner
@@ -58,10 +65,10 @@
               '<div class="workshop-banner-content">' +
                 '<div class="workshop-banner-header-row">' +
                   '<span class="workshop-banner-badge">' + (e.isPaid ? 'Workshop' : 'Akce') + '</span>' +
-                  '<span class="workshop-banner-date">' + dateText + '</span>' +
+                  '<span class="workshop-banner-date">' + esc(dateText) + '</span>' +
                 '</div>' +
-                '<div class="workshop-banner-title">' + e.title + '</div>' +
-                (e.bannerDescription ? '<div class="workshop-banner-desc">' + e.bannerDescription + '</div>' : '') +
+                '<div class="workshop-banner-title">' + esc(e.title) + '</div>' +
+                (e.bannerDescription ? '<div class="workshop-banner-desc">' + esc(e.bannerDescription) + '</div>' : '') +
                 earlyHtml +
               '</div>' +
               '<div class="workshop-banner-cta">' +
@@ -75,10 +82,10 @@
           '<a href="' + url + '" class="promo-card-compact-link">' +
             '<div class="promo-card-compact">' +
               '<div class="promo-left">' +
-                '<span class="promo-badge-sm">' + (isAd ? (e.badgeLabel || 'Tip') : 'Naše akce') + '</span>' +
-                '<span class="promo-title-sm">' + e.title + '</span>' +
-                (dateText ? '<span class="promo-meta">' + dateText + '</span>' : '') +
-                (e.bannerDescription ? '<span class="promo-meta">' + e.bannerDescription + '</span>' : '') +
+                '<span class="promo-badge-sm">' + (isAd ? esc(e.badgeLabel || 'Tip') : 'Naše akce') + '</span>' +
+                '<span class="promo-title-sm">' + esc(e.title) + '</span>' +
+                (dateText ? '<span class="promo-meta">' + esc(dateText) + '</span>' : '') +
+                (e.bannerDescription ? '<span class="promo-meta">' + esc(e.bannerDescription) + '</span>' : '') +
               '</div>' +
               '<div class="promo-right">' +
                 '<span class="promo-cta-btn">' + (isAd ? 'Více' : 'Detaily') + ' &rarr;</span>' +

--- a/static/js/promo-banner.js
+++ b/static/js/promo-banner.js
@@ -25,11 +25,18 @@
     .then(function (e) {
       if (!e || !e.slug) return;
 
-      var d = e.date.split('-');
-      var df = parseInt(d[2]) + '. ' + months[parseInt(d[1]) - 1] + ' ' + d[0];
-      var city = e.city || (e.location ? e.location.split(',').slice(-1)[0].trim() : '');
-      var dateText = df + (city ? ' · ' + city : '') +
-        (e.dateVariants && e.dateVariants.length > 1 ? ' · a další termíny' : '');
+      // Reklama / externí promo slot (isAd): nemá reálný termín ani město,
+      // místo „Naše akce" má vlastní štítek a CTA „Více". Datum se nezobrazuje.
+      var isAd = !!e.isAd;
+
+      var dateText = '';
+      if (!isAd && e.date) {
+        var d = e.date.split('-');
+        var df = parseInt(d[2]) + '. ' + months[parseInt(d[1]) - 1] + ' ' + d[0];
+        var city = e.city || (e.location ? e.location.split(',').slice(-1)[0].trim() : '');
+        dateText = df + (city ? ' · ' + city : '') +
+          (e.dateVariants && e.dateVariants.length > 1 ? ' · a další termíny' : '');
+      }
       var url = 'https://www.vibecoding.cz/akce/' + e.slug +
         '/?utm_source=marigold&utm_medium=web&utm_campaign=' + campaign;
 
@@ -68,13 +75,13 @@
           '<a href="' + url + '" class="promo-card-compact-link">' +
             '<div class="promo-card-compact">' +
               '<div class="promo-left">' +
-                '<span class="promo-badge-sm">Naše akce</span>' +
+                '<span class="promo-badge-sm">' + (isAd ? (e.badgeLabel || 'Tip') : 'Naše akce') + '</span>' +
                 '<span class="promo-title-sm">' + e.title + '</span>' +
-                '<span class="promo-meta">' + dateText + '</span>' +
+                (dateText ? '<span class="promo-meta">' + dateText + '</span>' : '') +
                 (e.bannerDescription ? '<span class="promo-meta">' + e.bannerDescription + '</span>' : '') +
               '</div>' +
               '<div class="promo-right">' +
-                '<span class="promo-cta-btn">Detaily &rarr;</span>' +
+                '<span class="promo-cta-btn">' + (isAd ? 'Více' : 'Detaily') + ' &rarr;</span>' +
               '</div>' +
             '</div>' +
           '</a>';


### PR DESCRIPTION
## Co a proč

Kompaktní banner (`promo-banner.js`) nově rozlišuje **reklamu (`isAd`)** od akce. Párová změna k `vibecoding-site#…` (reklamní sloty pro propagaci čehokoliv napříč weby).

## Změny

- **badge** — reklama použije `e.badgeLabel` (fallback `Tip`) místo natvrdo `Naše akce`
- **datum** — u reklamy se **nezobrazuje** (reklama nemá reálný termín); `dateText` se počítá jen při `!isAd && e.date`, takže je odolný i vůči chybějícímu datu
- **CTA** — reklama `Více →`, akce `Detaily →`

Workshop větev (`isPaid`) i skládání URL beze změny — reklama je vždy `isPaid:false` a její slug `r/<id>` korektně trefí redirect na vibecoding.cz. Akce se renderují **identicky jako dřív** (zpětně kompatibilní).

## Dosah

Stejný skript běží i na `/aiprace` (podstránka marigoldu), takže deploy pokryje obě místa.

## Ověřeno

- `node --check` — syntax OK
- Simulace render logiky: akce zobrazí datum + „Naše akce"; reklama vlastní badge bez data; fallback na „Tip"; prázdný slug skryje banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Tato PR rozšiřuje `promo-banner.js` o podporu reklamních slotů přes nový příznak `isAd`. Změna je zpětně kompatibilní — akce se vykreslují identicky jako dříve.

- **Badge a CTA**: pro reklamy se použije `e.badgeLabel` (fallback `'Tip'`) místo `'Naše akce'` a CTA se změní na `'Více'`.
- **Datum**: podmíněně skryto pro reklamy (`!isAd && e.date`), čímž se rovněž opravuje původní potenciální chyba při chybějícím datu.
- **Bezpečnost**: nové pole `e.badgeLabel` je vkládáno přímo do `innerHTML` bez HTML escapování — stejný vzor existuje i u `e.title` a `e.bannerDescription`, ale `e.badgeLabel` je nový vstupní bod.

<h3>Confidence Score: 4/5</h3>

Změna je zpětně kompatibilní a logika pro existující akce zůstává nedotčena; nový kód pro reklamy je přímočarý a dobře okomentovaný.

Přidání `e.badgeLabel` jako dalšího nekontrolovaného vstupu do `innerHTML` rozšiřuje existující vzor bez escapování o nový zdroj. Scénář kompromitace API je vzdálený, ale vzor si zaslouží pozornost.

Soubor `static/js/promo-banner.js` by měl projít bezpečnostní kontrolou HTML escapování pro všechny interpolované hodnoty z API.

<details open><summary><h3>Security Review</h3></summary>

- **XSS via `e.badgeLabel`** (`static/js/promo-banner.js`, řádek 78): nově přidané pole z API je vloženo do `innerHTML` bez escapování HTML znaků. Útočník s přístupem k API nebo při kompromitaci endpointu může vložit libovolný skript. Stejný vzor pre-existuje u `e.title` a `e.bannerDescription`, ale tato PR přidává nový nekontrolovaný vstupní bod.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| static/js/promo-banner.js | Přidána podpora reklamních slotů (isAd): podmíněné zobrazení data, vlastní badge štítek a odlišné CTA. Logika je zpětně kompatibilní, ale nové pole `e.badgeLabel` se vkládá do innerHTML bez escapování. |

</details>



<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[fetch /api/active-promotion] --> B{e && e.slug?}
    B -- Ne --> Z[return, banner skryt]
    B -- Ano --> C[isAd = !!e.isAd]
    C --> D{!isAd && e.date?}
    D -- Ano --> E[Vypočítat dateText: datum + město]
    D -- Ne --> F[dateText = '']
    E --> G{e.isPaid?}
    F --> G
    G -- Ano --> H[Workshop banner - dateText vždy zobrazen - CTA: Detaily]
    G -- Ne --> I{isAd?}
    I -- Ano --> J[badge: e.badgeLabel nebo Tip - bez data - CTA: Více]
    I -- Ne --> K[badge: Naše akce - s datem - CTA: Detaily]
    H --> L[container.style.display = '']
    J --> L
    K --> L
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[fetch /api/active-promotion] --> B{e && e.slug?}
    B -- Ne --> Z[return, banner skryt]
    B -- Ano --> C[isAd = !!e.isAd]
    C --> D{!isAd && e.date?}
    D -- Ano --> E[Vypočítat dateText: datum + město]
    D -- Ne --> F[dateText = '']
    E --> G{e.isPaid?}
    F --> G
    G -- Ano --> H[Workshop banner - dateText vždy zobrazen - CTA: Detaily]
    G -- Ne --> I{isAd?}
    I -- Ano --> J[badge: e.badgeLabel nebo Tip - bez data - CTA: Více]
    I -- Ne --> K[badge: Naše akce - s datem - CTA: Detaily]
    H --> L[container.style.display = '']
    J --> L
    K --> L
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `static/js/promo-banner.js`, line 61 ([link](https://github.com/tangero/marigold-page/blob/29fe4fc45c02e747d712dfdfffbd79c34ae53afb/static/js/promo-banner.js#L61)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Prázdný `<span>` pro datum v `isPaid` větvi**

   Pokud by API vrátilo `isAd:true` i `isPaid:true` současně (i přesto, že PR popis říká, že reklamy mají vždy `isPaid:false`), `dateText` bude prázdný řetězec, ale `<span class="workshop-banner-date"></span>` se přesto vykreslí, na rozdíl od kompaktního banneru, kde je datum podmíněně vynecháno. Obranné podmíněné vykreslování by zajistilo konzistentní chování v krajních případech.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: static/js/promo-banner.js
   Line: 61

   Comment:
   **Prázdný `<span>` pro datum v `isPaid` větvi**

   Pokud by API vrátilo `isAd:true` i `isPaid:true` současně (i přesto, že PR popis říká, že reklamy mají vždy `isPaid:false`), `dateText` bude prázdný řetězec, ale `<span class="workshop-banner-date"></span>` se přesto vykreslí, na rozdíl od kompaktního banneru, kde je datum podmíněně vynecháno. Obranné podmíněné vykreslování by zajistilo konzistentní chování v krajních případech.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20static%2Fjs%2Fpromo-banner.js%0ALine%3A%2061%0A%0AComment%3A%0A**Pr%C3%A1zdn%C3%BD%20%60%3Cspan%3E%60%20pro%20datum%20v%20%60isPaid%60%20v%C4%9Btvi**%0A%0APokud%20by%20API%20vr%C3%A1tilo%20%60isAd%3Atrue%60%20i%20%60isPaid%3Atrue%60%20sou%C4%8Dasn%C4%9B%20%28i%20p%C5%99esto%2C%20%C5%BEe%20PR%20popis%20%C5%99%C3%ADk%C3%A1%2C%20%C5%BEe%20reklamy%20maj%C3%AD%20v%C5%BEdy%20%60isPaid%3Afalse%60%29%2C%20%60dateText%60%20bude%20pr%C3%A1zdn%C3%BD%20%C5%99et%C4%9Bzec%2C%20ale%20%60%3Cspan%20class%3D%22workshop-banner-date%22%3E%3C%2Fspan%3E%60%20se%20p%C5%99esto%20vykresl%C3%AD%2C%20na%20rozd%C3%ADl%20od%20kompaktn%C3%ADho%20banneru%2C%20kde%20je%20datum%20podm%C3%ADn%C4%9Bn%C4%9B%20vynech%C3%A1no.%20Obrann%C3%A9%20podm%C3%ADn%C4%9Bn%C3%A9%20vykreslov%C3%A1n%C3%AD%20by%20zajistilo%20konzistentn%C3%AD%20chov%C3%A1n%C3%AD%20v%20krajn%C3%ADch%20p%C5%99%C3%ADpadech.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=tangero%2Fmarigold-page&pr=18&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Astatic%2Fjs%2Fpromo-banner.js%3A78%0A**XSS%20skrze%20nov%C3%A9%20pole%20%60e.badgeLabel%60**%0A%0A%60e.badgeLabel%60%20je%20nov%C4%9B%20vkl%C3%A1d%C3%A1n%20p%C5%99%C3%ADmo%20do%20%60innerHTML%60%20bez%20HTML%20escapov%C3%A1n%C3%AD.%20%60e.title%60%20a%20%60e.bannerDescription%60%20m%C4%9Bly%20stejn%C3%BD%20probl%C3%A9m%20u%C5%BE%20p%C5%99ed%20touto%20PR%2C%20ale%20%60e.badgeLabel%60%20je%20nov%C3%BD%20vstupn%C3%AD%20bod.%20Pokud%20by%20API%20na%20%60vibecoding.cz%60%20bylo%20kompromitov%C3%A1no%20nebo%20kdykoliv%20za%C4%8Dalo%20vracet%20nevalidn%C3%AD%20data%2C%20%C3%BAto%C4%8Dn%C3%ADk%20m%C5%AF%C5%BEe%20vlo%C5%BEit%20libovoln%C3%BD%20HTML%2FJS.%20Doporu%C4%8Duji%20p%C5%99idat%20pomocnou%20funkci%20%60escapeHtml%60%20%28nahrazuj%C3%ADc%C3%AD%20%60%26%60%2C%20%60%3C%60%2C%20%60%3E%60%2C%20%60%22%60%2C%20%60'%60%29%20a%20pou%C5%BE%C3%ADt%20ji%20na%20v%C5%A1echny%20interpolovan%C3%A9%20%C5%99et%C4%9Bzce%20z%20API.%0A%0A%23%23%23%20Issue%202%20of%202%0Astatic%2Fjs%2Fpromo-banner.js%3A61%0A**Pr%C3%A1zdn%C3%BD%20%60%3Cspan%3E%60%20pro%20datum%20v%20%60isPaid%60%20v%C4%9Btvi**%0A%0APokud%20by%20API%20vr%C3%A1tilo%20%60isAd%3Atrue%60%20i%20%60isPaid%3Atrue%60%20sou%C4%8Dasn%C4%9B%20%28i%20p%C5%99esto%2C%20%C5%BEe%20PR%20popis%20%C5%99%C3%ADk%C3%A1%2C%20%C5%BEe%20reklamy%20maj%C3%AD%20v%C5%BEdy%20%60isPaid%3Afalse%60%29%2C%20%60dateText%60%20bude%20pr%C3%A1zdn%C3%BD%20%C5%99et%C4%9Bzec%2C%20ale%20%60%3Cspan%20class%3D%22workshop-banner-date%22%3E%3C%2Fspan%3E%60%20se%20p%C5%99esto%20vykresl%C3%AD%2C%20na%20rozd%C3%ADl%20od%20kompaktn%C3%ADho%20banneru%2C%20kde%20je%20datum%20podm%C3%ADn%C4%9Bn%C4%9B%20vynech%C3%A1no.%20Obrann%C3%A9%20podm%C3%ADn%C4%9Bn%C3%A9%20vykreslov%C3%A1n%C3%AD%20by%20zajistilo%20konzistentn%C3%AD%20chov%C3%A1n%C3%AD%20v%20krajn%C3%ADch%20p%C5%99%C3%ADpadech.%0A%0A&repo=tangero%2Fmarigold-page&pr=18&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
static/js/promo-banner.js:78
**XSS skrze nové pole `e.badgeLabel`**

`e.badgeLabel` je nově vkládán přímo do `innerHTML` bez HTML escapování. `e.title` a `e.bannerDescription` měly stejný problém už před touto PR, ale `e.badgeLabel` je nový vstupní bod. Pokud by API na `vibecoding.cz` bylo kompromitováno nebo kdykoliv začalo vracet nevalidní data, útočník může vložit libovolný HTML/JS. Doporučuji přidat pomocnou funkci `escapeHtml` (nahrazující `&`, `<`, `>`, `"`, `'`) a použít ji na všechny interpolované řetězce z API.

### Issue 2 of 2
static/js/promo-banner.js:61
**Prázdný `<span>` pro datum v `isPaid` větvi**

Pokud by API vrátilo `isAd:true` i `isPaid:true` současně (i přesto, že PR popis říká, že reklamy mají vždy `isPaid:false`), `dateText` bude prázdný řetězec, ale `<span class="workshop-banner-date"></span>` se přesto vykreslí, na rozdíl od kompaktního banneru, kde je datum podmíněně vynecháno. Obranné podmíněné vykreslování by zajistilo konzistentní chování v krajních případech.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(promo-banner): support ad slots (is..."](https://github.com/tangero/marigold-page/commit/29fe4fc45c02e747d712dfdfffbd79c34ae53afb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38486001)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->